### PR TITLE
Add database name to end of DATABASE_URL

### DIFF
--- a/.env_dev_local_db_template
+++ b/.env_dev_local_db_template
@@ -4,6 +4,6 @@ export STATIC_FILES_ADMINDASH_PORT=5002
 export DOMAIN_OVERRIDE=localhost:5000
 export PORT=5000
 export STRIPE_SECRET_KEY=sk_test_NFBDEThkpHCYBzXPJuBlY8TW
-export DATABASE_URL=postgres://your_pg_username:your_pg_password@localhost:5432
+export DATABASE_URL=postgres://your_pg_username:your_pg_password@localhost:5432/your_pg_database_name
 export DATABASE_FOR_READS_NAME=DATABASE_URL
 export DISABLE_INTERCOM=true


### PR DESCRIPTION
### Issue(s)

To connect correctly, the DATABASE_URL needs the name of the database

### Areas Affected

`.env_dev_local_db_template`