### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint": "^2.10.2",
     "express": "3.21.2",
     "fb": "1.0.2",
-    "gulp": "3.8.11",
     "http-proxy": "0.10.4",
     "intercom-client": "^2.8.0",
     "intercom.io": "^1.2.1",


### PR DESCRIPTION
### Issue(s)

Gulp is listed as dependency, but it does not appear to actually be called in any of the js files. 

Removing it:

* Ensures `package.json` more accurately reflects what's in use
* One less package to install 🙌 