### PR TITLE
Dockerize dgps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 .google_creds_temp
 npm-debug.log
 node_modules
+*~
+*#
+env_dev
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,30 +11,30 @@ FROM node:10.9.0
 # sudo docker container run --network="host" --publish 5000:5000 --detach --name polis-server polis-server:1.0
 
 
-ARG host=localhost
-ARG port=5000
+# ARG host=localhost
+# ARG port=5000
 
-ARG static_files_host=localhost
-ARG static_files_port=5001
+# ARG static_files_host=localhost
+# ARG static_files_port=5001
 
-ARG static_files_admin_host=localhost
-ARG static_files_admin_port=5002
+# ARG static_files_admin_host=localhost
+# ARG static_files_admin_port=5002
 
-# database credentials are defined in .env file
-#ARG postgres_host=localhost
-#ARG postgres_port=5432
-#ARG postgres_uid=postgres
-#ARG postgres_pwd=postgres
-#ARG postgres_db=polis-dev
-#ENV DATABASE_URL postgres://${postgres_uid}:${postgres_pwd}@${postgres_host}:${postgres_port}/${postgres_db}
+# # database credentials are defined in .env file
+# #ARG postgres_host=localhost
+# #ARG postgres_port=5432
+# #ARG postgres_uid=postgres
+# #ARG postgres_pwd=postgres
+# #ARG postgres_db=polis-dev
+# #ENV DATABASE_URL postgres://${postgres_uid}:${postgres_pwd}@${postgres_host}:${postgres_port}/${postgres_db}
 
-ENV DOMAIN_OVERRIDE ${host}:${port}
-ENV PORT ${port}
+# ENV DOMAIN_OVERRIDE ${host}:${port}
+# ENV PORT ${port}
 
-ENV STATIC_FILES_HOST ${static_files_host}
-ENV STATIC_FILES_PORT ${static_files_port}
-ENV STATIC_FILES_ADMINDASH_PORT ${static_files_admin_port}
-ENV DISABLE_INTERCOM="true"
+# ENV STATIC_FILES_HOST ${static_files_host}
+# ENV STATIC_FILES_PORT ${static_files_port}
+# ENV STATIC_FILES_ADMINDASH_PORT ${static_files_admin_port}
+# ENV DISABLE_INTERCOM="true"
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,51 @@
-FROM node:6
+FROM node:10.9.0
 
-# For admin functionality, fill this out
-ENV ADMIN_EMAILS []
-ENV ADMIN_EMAIL_DATA_EXPORT ""
-ENV ADMIN_EMAIL_DATA_EXPORT_TEST ""
-ENV ADMIN_EMAIL_EMAIL_TEST ""
-ENV ADMIN_UIDS []
+# sudo docker image build -t polis-server:1.0 .
+# sudo docker container run --network="host" --publish 5000:5000 --detach --name polis-server polis-server:1.0
+# sudo docker container kill polis-server
+# sudo docker container rm polis-server
+# sudo docker logs polis-server
+# --network="host"
 
-ENV DATABASE_FOR_READS_NAME DATABASE_URL
-ENV DATABASE_URL postgres://postgres:oiPorg3Nrz0yqDLE@postgres:5432/polis-dev
-ENV DEV_MODE true
-ENV DISABLE_INTERCOM true
-ENV DOMAIN_OVERRIDE localhost:5000
-ENV PORT 5000
-ENV STATIC_FILES_ADMINDASH_PORT 5002
-ENV STATIC_FILES_HOST localhost
-ENV STATIC_FILES_PORT 5001
-ENV STRIPE_SECRET_KEY sk_test_NFBDEThkpHCYBzXPJuBlY8TW
+# sudo docker container kill polis-server; sudo docker container rm polis-server; sudo docker image build -t polis-server:1.0 .
+# sudo docker container run --network="host" --publish 5000:5000 --detach --name polis-server polis-server:1.0
+
+
+ARG host=localhost
+ARG port=5000
+
+ARG static_files_host=localhost
+ARG static_files_port=5001
+
+ARG static_files_admin_host=localhost
+ARG static_files_admin_port=5002
+
+# database credentials are defined in .env file
+#ARG postgres_host=localhost
+#ARG postgres_port=5432
+#ARG postgres_uid=postgres
+#ARG postgres_pwd=postgres
+#ARG postgres_db=polis-dev
+#ENV DATABASE_URL postgres://${postgres_uid}:${postgres_pwd}@${postgres_host}:${postgres_port}/${postgres_db}
+
+ENV DOMAIN_OVERRIDE ${host}:${port}
+ENV PORT ${port}
+
+ENV STATIC_FILES_HOST ${static_files_host}
+ENV STATIC_FILES_PORT ${static_files_port}
+ENV STATIC_FILES_ADMINDASH_PORT ${static_files_admin_port}
+ENV DISABLE_INTERCOM="true"
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY . .
+
 RUN npm install
 
-ADD . .
+EXPOSE ${port}
 
-EXPOSE 5000
-CMD node --max_old_space_size=400 --gc_interval=100 --harmony app.js
+#CMD npm run docker
+
+CMD ["node", "--max_old_space_size=400", "--gc_interval=100", "--harmony", "app.js" ]
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,12 @@
 FROM node:10.9.0
 
-# sudo docker image build -t polis-server:1.0 .
-# sudo docker container run --network="host" --publish 5000:5000 --detach --name polis-server polis-server:1.0
-# sudo docker container kill polis-server
-# sudo docker container rm polis-server
-# sudo docker logs polis-server
-# --network="host"
-
-# sudo docker container kill polis-server; sudo docker container rm polis-server; sudo docker image build -t polis-server:1.0 .
-# sudo docker container run --network="host" --publish 5000:5000 --detach --name polis-server polis-server:1.0
-
-
-# ARG host=localhost
-# ARG port=5000
-
-# ARG static_files_host=localhost
-# ARG static_files_port=5001
-
-# ARG static_files_admin_host=localhost
-# ARG static_files_admin_port=5002
-
-# # database credentials are defined in .env file
-# #ARG postgres_host=localhost
-# #ARG postgres_port=5432
-# #ARG postgres_uid=postgres
-# #ARG postgres_pwd=postgres
-# #ARG postgres_db=polis-dev
-# #ENV DATABASE_URL postgres://${postgres_uid}:${postgres_pwd}@${postgres_host}:${postgres_port}/${postgres_db}
-
-# ENV DOMAIN_OVERRIDE ${host}:${port}
-# ENV PORT ${port}
-
-# ENV STATIC_FILES_HOST ${static_files_host}
-# ENV STATIC_FILES_PORT ${static_files_port}
-# ENV STATIC_FILES_ADMINDASH_PORT ${static_files_admin_port}
-# ENV DISABLE_INTERCOM="true"
-
 WORKDIR /app
 
-COPY . .
+COPY *.json ./
 
 RUN npm install
+
+COPY . .
 
 EXPOSE ${port}
 

--- a/app.js
+++ b/app.js
@@ -57,6 +57,7 @@ helpersInitialized.then(function(o) {
     haltOnTimeout,
     HMAC_SIGNATURE_PARAM_NAME,
     hostname,
+    hostnameForAdminFiles,
     makeFileFetcher,
     makeRedirectorTo,
     moveToBody,
@@ -1330,10 +1331,10 @@ helpersInitialized.then(function(o) {
   app.get(/^\/conversations(\/.*)?/, fetchIndexForAdminPage);
   app.get(/^\/signout(\/.*)?/, fetchIndexForAdminPage);
   app.get(/^\/signin(\/.*)?/, fetchIndexForAdminPage);
-  app.get(/^\/dist\/admin_bundle.js$/, makeFileFetcher(hostname, portForAdminFiles, "/dist/admin_bundle.js", {
+  app.get(/^\/dist\/admin_bundle.js$/, makeFileFetcher(hostnameForAdminFiles, portForAdminFiles, "/dist/admin_bundle.js", {
     'Content-Type': "application/javascript",
   }));
-  app.get(/^\/__webpack_hmr$/, makeFileFetcher(hostname, portForAdminFiles, "/__webpack_hmr", {
+  app.get(/^\/__webpack_hmr$/, makeFileFetcher(hostnameForAdminFiles, portForAdminFiles, "/__webpack_hmr", {
     'Content-Type': "eventsource",
   }));
   app.get(/^\/privacy$/, fetchIndexForAdminPage);
@@ -1365,16 +1366,16 @@ helpersInitialized.then(function(o) {
   app.get(/^\/thirdPartyCookieTestPt1\.html$/, fetchThirdPartyCookieTestPt1);
   app.get(/^\/thirdPartyCookieTestPt2\.html$/, fetchThirdPartyCookieTestPt2);
 
-  app.get(/^\/embed$/, makeFileFetcher(hostname, portForAdminFiles, "/embed.html", {
+  app.get(/^\/embed$/, makeFileFetcher(hostnameForAdminFiles, portForAdminFiles, "/embed.html", {
     'Content-Type': "text/html",
   }));
-  app.get(/^\/embedPreprod$/, makeFileFetcher(hostname, portForAdminFiles, "/embedPreprod.html", {
+  app.get(/^\/embedPreprod$/, makeFileFetcher(hostnameForAdminFiles, portForAdminFiles, "/embedPreprod.html", {
     'Content-Type': "text/html",
   }));
-  app.get(/^\/embedReport$/, makeFileFetcher(hostname, portForAdminFiles, "/embedReport.html", {
+  app.get(/^\/embedReport$/, makeFileFetcher(hostnameForAdminFiles, portForAdminFiles, "/embedReport.html", {
     'Content-Type': "text/html",
   }));
-  app.get(/^\/embedReportPreprod$/, makeFileFetcher(hostname, portForAdminFiles, "/embedReportPreprod.html", {
+  app.get(/^\/embedReportPreprod$/, makeFileFetcher(hostnameForAdminFiles, portForAdminFiles, "/embedReportPreprod.html", {
     'Content-Type': "text/html",
   }));
   app.get(/^\/canvas_setup_backup_instructions$/, makeFileFetcher(hostname, portForParticipationFiles, "/canvas_setup_backup_instructions.html", {
@@ -1431,7 +1432,7 @@ helpersInitialized.then(function(o) {
   var missingFilesGet404 = false;
   if (missingFilesGet404) {
     // 404 everything else
-    app.get(/^\/[^(api\/)]?.*/, makeFileFetcher(hostname, portForAdminFiles, "/404.html", {
+    app.get(/^\/[^(api\/)]?.*/, makeFileFetcher(hostnameForAdminFiles, portForAdminFiles, "/404.html", {
       'Content-Type': "text/html",
     }));
   } else {
@@ -1442,6 +1443,8 @@ helpersInitialized.then(function(o) {
   app.listen(process.env.PORT);
 
   winston.log("info", 'started on port ' + process.env.PORT);
+  winston.log("info", 'host for user files (app.js): ' + hostname + ':' + portForParticipationFiles);
+  winston.log("info", 'host for admin files (app.js): ' + hostnameForAdminFiles + ':' + portForAdminFiles);
 
 }, function(err) {
   console.error("failed to init server");

--- a/server.js
+++ b/server.js
@@ -14435,6 +14435,7 @@ CREATE TABLE slack_user_invites (
 
   // serve up index.html in response to anything starting with a number
   let hostname = process.env.STATIC_FILES_HOST;
+  let hostnameForAdminFiles = process.env.STATIC_FILES_ADMINDASH;
   let portForParticipationFiles = process.env.STATIC_FILES_PORT;
   let portForAdminFiles = process.env.STATIC_FILES_ADMINDASH_PORT;
 
@@ -14494,7 +14495,7 @@ CREATE TABLE slack_user_invites (
   }
 
 
-  let fetch404Page = makeFileFetcher(hostname, portForAdminFiles, "/404.html", {
+  let fetch404Page = makeFileFetcher(hostnameForAdminFiles, portForAdminFiles, "/404.html", {
     'Content-Type': "text/html",
   });
 
@@ -14538,10 +14539,10 @@ CREATE TABLE slack_user_invites (
   }
 
 
-  let fetchIndexForAdminPage = makeFileFetcher(hostname, portForAdminFiles, "/index_admin.html", {
+  let fetchIndexForAdminPage = makeFileFetcher(hostnameForAdminFiles, portForAdminFiles, "/index_admin.html", {
     'Content-Type': "text/html",
   });
-  let fetchIndexForReportPage = makeFileFetcher(hostname, portForAdminFiles, "/index_report.html", {
+  let fetchIndexForReportPage = makeFileFetcher(hostnameForAdminFiles, portForAdminFiles, "/index_report.html", {
     'Content-Type': "text/html",
   });
 

--- a/server.js
+++ b/server.js
@@ -2474,6 +2474,7 @@ function initializePolisHelpers() {
     process.env.DOMAIN_WHITELIST_ITEM_06,
     process.env.DOMAIN_WHITELIST_ITEM_07,
     process.env.DOMAIN_WHITELIST_ITEM_08,
+    "localhost:5000",
     "localhost:5001",
     "localhost:5002",
     "canvas.instructure.com", // LTI
@@ -14359,9 +14360,11 @@ CREATE TABLE slack_user_invites (
   };
 
   function makeFileFetcher(hostname, port, path, headers, preloadData) {
-
     return function(req, res) {
-      let hostname = buildStaticHostname(req, res);
+      if (!(isTrue(process.env.USE_DOCKER_COMPOSE) &&
+            isTrue(process.env.DEV_MODE))){
+	let hostname = buildStaticHostname(req, res);
+      }
       if (!hostname) {
         fail(res, 500, "polis_err_file_fetcher_serving_to_domain");
         console.error(req.headers.host);
@@ -14438,7 +14441,8 @@ CREATE TABLE slack_user_invites (
   let hostnameForAdminFiles = process.env.STATIC_FILES_ADMINDASH;
   let portForParticipationFiles = process.env.STATIC_FILES_PORT;
   let portForAdminFiles = process.env.STATIC_FILES_ADMINDASH_PORT;
-
+  winston.log("info", 'host for user files (server.js): ' + hostname + ':' + portForParticipationFiles);
+  winston.log("info", 'host for admin files (server.js): ' + hostnameForAdminFiles + ':' + portForAdminFiles);
 
   let fetchUnsupportedBrowserPage = makeFileFetcher(hostname, portForParticipationFiles, "/unsupportedBrowser.html", {
     'Content-Type': "text/html",
@@ -14766,6 +14770,7 @@ CREATE TABLE slack_user_invites (
     haltOnTimeout,
     HMAC_SIGNATURE_PARAM_NAME,
     hostname,
+    hostnameForAdminFiles,
     makeFileFetcher,
     makeRedirectorTo,
     moveToBody,


### PR DESCRIPTION
This is the first of 4 pull requests to enable pol-is to run in dev mode using docker-compose. To see all 4 pull requests working together, please follow the instructions at https://github.com/pol-is/polis-issues/issues/125. 

1. This request should not break any existing functionality. 
1.	This request makes minor changes to `.gitignore`.
2.	This request simplifies the `Dockerfile`. Because all pol-is components can share a common env_file, maintenance will be easier if ENV setting are not included in Dockerfiles. 
3.	This request defines a new variable ` hostnameForAdminFiles` so that `polisClientAdmin` and `polisClientParticipation` can run in different containers with different IP addresses. 
4.	This request defines a new environment variable `USE_DOCKER_COMPOSE` that allows `makeFileFetcher` to interact with ` hostnameForAdminFiles` so that `polisClientAdmin running in different containers.


