### PR TITLE
Added InSpec smoke tests for docker build (via GitHub Actions)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: Test Docker Build
+
+on:
+  push:
+
+jobs:
+  test-docker-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - uses: docker/build-push-action@v1
+      env:
+        DOCKER_BUILDKIT: 1
+      with:
+        repository: polis-server
+        push: false
+        tags: latest
+
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+
+    - run: |
+        gem install inspec-bin --no-document
+
+    - name: Start container
+      run: |
+        docker run --detach --name build --publish 5000:5000 polis-server
+
+    - name: Smoke test endpoint
+      env:
+        CHEF_LICENSE: accept-silent
+      run: |
+        inspec exec inspec/tests.rb --target docker://build --color
+
+    - name: Kill container
+      run: docker kill build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: Test Docker Build
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test-docker-build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:10
 
 # For admin functionality, fill this out
 ENV ADMIN_EMAILS []

--- a/inspec/tests.rb
+++ b/inspec/tests.rb
@@ -1,0 +1,16 @@
+# InSpec tests for checking if container is running properly.
+# See: https://www.inspec.io/docs/reference/resources/
+
+describe port(5000) do
+  it { should be_listening }
+end
+
+describe processes('^node .+ app.js') do
+  it { should exist }
+  its('entries.length') { should eq 1 }
+end
+
+describe http('http://localhost:5000/perfStats_9182738127') do
+  its('status') { should eq 200 }
+  its('body') { should eq '{}' }
+end

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {
-    "node": "10.9.0",
+    "node": "10.x",
     "npm": "6.4.1"
   },
   "repository": {


### PR DESCRIPTION
**InSpec** is a way to test infrastructure based on logging into system and running tests to check the state of the system.
https://www.inspec.io/docs/reference/resources/

I noticed that there had been quite a bit of third-party work around docker, but that some of the PRs were understandably taking some time to merge with care. I thought maybe having infra tests to validate key defintions of "working" might allow piecemeal acceptance of contributions, so long as they don't break docker builds. Thinking we could perhaps add more as we start up a minimal testing suite.

This doesn't change any part of the docker setup now, but simply added some quick tests to check an non-authenticated endpoint for a response.

Let me know if this seems like a good-enough baby-step :) If so, I'll add docs and get the merge-ready.

## To Do
- [ ] add documentation
- [ ] ensure it only runs on master branch and PRs