### PR TITLE
Switch from git to https protocol in bower

### DIFF
--- a/client-participation/bower.json
+++ b/client-participation/bower.json
@@ -2,14 +2,14 @@
   "name": "dashboard-require",
   "version": "0.0.0",
   "dependencies": {
-    "backbone": "git://github.com/mbjorkegren/backbone#polis",
+    "backbone": "https://github.com/mbjorkegren/backbone.git#polis",
     "underscore": "~1.5.2",
     "thorax": "~2.0",
     "bootstrap": "~3.1.1",
     "d3": "~3.5.17",
     "font-awesome": "~4.1.0",
     "d3-tip": "<=0.6.4",
-    "handlebones": "git://github.com/mbjorkegren/handlebones#master",
+    "handlebones": "https://github.com/mbjorkegren/handlebones.git#master",
     "bootstrap-sass-official": "~3.2.0",
     "markdown": "~0.5.0",
     "deepcopy": "~0.4.0"


### PR DESCRIPTION
Fetching with git:// sometimes poses issue on some networks.

Addresses https://github.com/pol-is/polisServer/issues/89

Builds fine in docker.

Theoretically it means someone might need to type a github password (or edit the git remote url) if they try to edit and push a change directly from the fetched artefact, but I'd suggest that bad developer experience in restricted [government] networks is more important to address.

cc: @urakagi