### PR TITLE
Replace "demo" link with "register" one

### DIFF
--- a/client-admin/src/components/App/Nav/Nav.js
+++ b/client-admin/src/components/App/Nav/Nav.js
@@ -3,7 +3,7 @@ import Logo from "../../Core/Logo/Logo";
 import { throttle } from "lodash";
 
 const t = {
-  cta: "Request a demo",
+  register: "Register",
   signin: "Sign In"
 };
 
@@ -28,8 +28,8 @@ class Nav extends React.Component {
           <a href="/signin" className="link mr4 white">
             {t.signin}
           </a>
-          <a href="/demo" ref={button => (this.button = button)} className="br2 ba ph2 pv2  ttu white   w-100 w-auto-ns   mt3 mt0-ns link">
-            {t.cta}
+          <a href="/createuser" ref={button => (this.button = button)} className="br2 ba ph2 pv2  ttu white   w-100 w-auto-ns   mt3 mt0-ns link">
+            {t.register}
           </a>
         </div>
       </nav>;


### PR DESCRIPTION
Re-ticketed from https://github.com/pol-is/polisServer/issues/232#issuecomment-624234995

@urakagi's commits for upstreaming.

Added a link to get to registration page.

Should we also remove the demo page as part of this?