### PR TITLE
Allow opinion group comment explorer to show auto-translations

### DIFF
--- a/client-participation/js/stores/polis.js
+++ b/client-participation/js/stores/polis.js
@@ -1718,6 +1718,7 @@ module.exports = function(params) {
   }
 
   function getFancyComments(options) {
+    options = $.extend(options, { translate: true, lang: navigator.language });
     return $.when(getComments(options), votesForTidBidPromise).then(function(args /* , dont need second arg */ ) {
 
       var comments = args[0];

--- a/client-participation/vis2/components/exploreTid.js
+++ b/client-participation/vis2/components/exploreTid.js
@@ -211,6 +211,15 @@ class ExploreTid extends React.Component {
   }
   render() {
     if (!this.props.selectedComment) {return null}
+    let translatedText = null;
+    if (this.props.selectedComment.translatedText) {
+      let lang = navigator.language;
+      if (lang.indexOf('-') > 0) {
+        lang = lang.split('-')[0];
+        // Do not need undefined check, will just not appear
+        translatedText = this.props.selectedComment.translatedText[lang];
+      }
+    }
     return (
       <div style={{
           borderRadius: 4,
@@ -241,6 +250,8 @@ class ExploreTid extends React.Component {
             fontFamily: "Georgia, serif",
           }}>
             {this.props.selectedComment ? this.props.selectedComment.txt : null}
+            {translatedText ? <hr/> : null}
+            {translatedText ? translatedText : null}
           </p>
           <DataSentence
             math={this.props.math}


### PR DESCRIPTION
Re-ticketed from https://github.com/pol-is/polisServer/issues/232#issuecomment-624345233

@urakagi's commits for upstreaming.

This should allow comments below viz to be translated when exploring opinion groups.

Needs local testing with translation enabled. Will post screenshots

## Screenshots (Before)

### Comment voting (allow translation)

<img width="1280" alt="Screen Shot 2020-10-01 at 2 17 36 PM" src="https://user-images.githubusercontent.com/305339/94847785-091f9b00-03f1-11eb-988f-286c09251949.png">

### Comment explorer (no translations)

<img width="1350" alt="Screen Shot 2020-10-01 at 2 17 30 PM" src="https://user-images.githubusercontent.com/305339/94847759-00c76000-03f1-11eb-81ba-cf71bc529470.png">

## To Do

- [x] extract feature from PDIS fork
- [ ] spin up feature branch to test
- [ ] add screenshot here
- [x] add GTranslate credentials to CI
- [ ] stretch: create e2e test