### PR TITLE
Make GIT_HASH optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Recommendations: Docker-Machine (on [DigitalOcean with 2GB memory][do-tut])
    [do-tut]: https://www.digitalocean.com/community/tutorials/how-to-provision-and-manage-remote-docker-hosts-with-docker-machine-on-ubuntu-16-04
 
 ```
-GIT_HASH=$(git log --pretty="%h" -n 1) docker-compose up --build --detach
+docker-compose up --build --detach
 docker-machine ip
 >>> 123.45.67.89
 ```

--- a/client-admin/Dockerfile
+++ b/client-admin/Dockerfile
@@ -1,8 +1,6 @@
 # Requires a very specific version due to package bugs and version compatibility
 FROM node:6.10.3
 
-ARG GIT_HASH
-
 WORKDIR /app
 
 RUN npm install -g gulp
@@ -17,4 +15,5 @@ ADD polis.config.template.js polis.config.js
 
 ADD . .
 
+ARG GIT_HASH
 RUN gulp deployPreprod

--- a/client-admin/gulpfile.js
+++ b/client-admin/gulpfile.js
@@ -54,16 +54,10 @@ function getGitHash() {
   return new Promise(function(resolve, reject) {
     if (process.env.GIT_HASH) {
       resolve(process.env.GIT_HASH)
-      return
+    } else {
+      console.log('Not GIT_HASH provided. Skipping use.');
+      resolve()
     }
-    exec("git log --pretty=\"%h\" -n 1", function(error, stdout, stderr) {
-      if (error) {
-        console.error('FAILED TO GET GIT HASH: ' + error);
-        reject(stderr);
-      } else {
-        resolve(stdout);
-      }
-    })
   });
 }
 
@@ -171,10 +165,15 @@ gulp.task("configureForProduction", function(callback) {
   console.log('getGitHash begin');
   // NOTE using callback instead of returning a promise since the promise isn't doing the trick - haven't tried updating gulp yet.
   getGitHash().then(function(hash) {
-    hash = hash.toString().match(/[A-Za-z0-9]+/)[0];
-
     var d = new Date();
-    var unique_token = [d.getFullYear(), d.getMonth() + 1, d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds(), hash].join("_");
+    var tokenParts = [d.getFullYear(), d.getMonth() + 1, d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds()];
+
+    if (hash) {
+      hash = hash.toString().match(/[A-Za-z0-9]+/)[0];
+      tokenParts.push(hash);
+    }
+
+    var unique_token = tokenParts.join("_");
     destRootRest = [staticFilesPrefix, unique_token].join("/");
     versionString = unique_token;
 

--- a/client-participation/Dockerfile
+++ b/client-participation/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:10.15.0
 
-ARG GIT_HASH
-
 WORKDIR /app
 
 RUN npm install -g gulp
@@ -16,4 +14,5 @@ ADD polis.config.template.js polis.config.js
 
 ADD . .
 
+ARG GIT_HASH
 RUN gulp deployPreprod

--- a/client-participation/gulpfile.js
+++ b/client-participation/gulpfile.js
@@ -196,16 +196,10 @@ function getGitHash() {
   return new Promise(function(resolve, reject) {
     if (process.env.GIT_HASH) {
       resolve(process.env.GIT_HASH)
-      return
+    } else {
+      console.log('No GIT_HASH provided. Skipping use.');
+      resolve()
     }
-    exec("git log --pretty=\"%h\" -n 1", function(error, stdout, stderr) {
-      if (error) {
-        console.error('FAILED TO GET GIT HASH: ' + error);
-        reject(stderr);
-      } else {
-        resolve(stdout);
-      }
-    })
   });
 }
 
@@ -596,10 +590,15 @@ gulp.task("configureForProduction", function(callback) {
   console.log('getGitHash begin');
   // NOTE using callback instead of returning a promise since the promise isn't doing the trick - haven't tried updating gulp yet.
   getGitHash().then(function(hash) {
-    hash = hash.toString().match(/[A-Za-z0-9]+/)[0];
-
     var d = new Date();
-    var unique_token = [d.getFullYear(), d.getMonth() + 1, d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds(), hash].join("_");
+    var tokenParts = [d.getFullYear(), d.getMonth() + 1, d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds()];
+
+    if (hash) {
+      hash = hash.toString().match(/[A-Za-z0-9]+/)[0];
+      tokenParts.push(hash);
+    }
+
+    var unique_token = tokenParts.join("_");
     destRootRest = [staticFilesPrefix, unique_token].join("/");
     versionString = unique_token;
 

--- a/client-report/Dockerfile
+++ b/client-report/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:10.15.0
 
-ARG GIT_HASH
-
 WORKDIR /app
 
 RUN npm install -g gulp
@@ -13,4 +11,5 @@ ADD polis.config.template.js polis.config.js
 
 ADD . .
 
+ARG GIT_HASH
 RUN gulp deployPreprod

--- a/client-report/gulpfile.js
+++ b/client-report/gulpfile.js
@@ -51,16 +51,10 @@ function getGitHash() {
   return new Promise(function(resolve, reject) {
     if (process.env.GIT_HASH) {
       resolve(process.env.GIT_HASH)
-      return
+    } else {
+      console.log('Not GIT_HASH provided. Skipping use.');
+      resolve()
     }
-    exec("git log --pretty=\"%h\" -n 1", function(error, stdout, stderr) {
-      if (error) {
-        console.error('FAILED TO GET GIT HASH: ' + error);
-        reject(stderr);
-      } else {
-        resolve(stdout);
-      }
-    })
   });
 }
 
@@ -112,10 +106,15 @@ gulp.task("configureForProduction", function(callback) {
   console.log('getGitHash begin');
   // NOTE using callback instead of returning a promise since the promise isn't doing the trick - haven't tried updating gulp yet.
   getGitHash().then(function(hash) {
-    hash = hash.toString().match(/[A-Za-z0-9]+/)[0];
-
     var d = new Date();
-    var unique_token = [d.getFullYear(), d.getMonth() + 1, d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds(), hash].join("_");
+    var tokenParts = [d.getFullYear(), d.getMonth() + 1, d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds()];
+
+    if (hash) {
+      hash = hash.toString().match(/[A-Za-z0-9]+/)[0];
+      tokenParts.push(hash);
+    }
+
+    var unique_token = tokenParts.join("_");
     destRootRest = [staticFilesPrefix, unique_token].join("/");
     versionString = unique_token;
 


### PR DESCRIPTION
Closes https://github.com/pol-is/polisServer/issues/243

Perhaps more importantly, this also _significantly_ improves caching usage for docker (#233), and makes docker-only development MUCH more bearable. (It no longer forces a toss of the long-running docker layer in which `npm install` runs, which was previously happened on each new git commit 🤦 )

I'm hoping this can be merged in sooner, as it will speed up other dev work 🎉 