### PR TITLE
allow for build_args to override the docker image tag

### DIFF
--- a/file-server/Dockerfile
+++ b/file-server/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG=dev
+ARG TAG=latest
 
 FROM polisdemo/client-admin:${TAG}          as admin
 FROM polisdemo/client-participation:${TAG}  as participation

--- a/file-server/Dockerfile
+++ b/file-server/Dockerfile
@@ -1,3 +1,9 @@
+ARG TAG=dev
+
+FROM polisdemo/client-admin:${TAG}          as admin
+FROM polisdemo/client-participation:${TAG}  as participation
+FROM polisdemo/client-report:${TAG}         as report
+
 FROM node:10.20.1-alpine
 
 WORKDIR /app
@@ -9,9 +15,10 @@ RUN npm ci
 COPY . .
 COPY fs_config.template.json fs_config.json
 
-COPY --from=polisdemo/client-report:dev /app/build/ ./build/
-COPY --from=polisdemo/client-admin:dev /app/build/ ./build/
-COPY --from=polisdemo/client-participation:dev /app/build/ ./build/
+RUN mkdir /app/build
+COPY --from=admin         /app/build/ /app/build
+COPY --from=participation /app/build/ /app/build
+COPY --from=report        /app/build/ /app/build
 
 EXPOSE 8080
 


### PR DESCRIPTION
Do nothing: it will build as before, using the polisdemo/client-*:dev images

Optionally, build with --build-arg TAG=latest
or any other valid docker image tag, to build the static client-* images with that tag instead of :dev