### PR TITLE
Refactor cypress tests

### DIFF
--- a/e2e/cypress/integration/polis/client-admin/create_user.spec.js
+++ b/e2e/cypress/integration/polis/client-admin/create_user.spec.js
@@ -1,37 +1,22 @@
 describe('Create User', () => {
-  afterEach(() => cy.visit('/signout'))
-
   beforeEach(() => {
-    cy.visit('/signout')
-    cy.visit('/createuser')
+    // Cypress doesn't believe in cleanup.
+    // See: https://docs.cypress.io/guides/references/best-practices.html#State-reset-should-go-before-each-test
+    cy.logout()
   })
 
-  before(async function () {
-    const users = await cy.fixture('users')
-    this.user = users[0]
+  before(() => {
+    cy.fixture('users.json').as('users')
   })
 
-  it('Does not create a new user with existing email address', () => {
+  it('Does not create a new user with existing email address', function () {
+    const user = this.users[0]
+
     // Create user.
-    cy.get('form').within(function () {
-      cy.get('input[placeholder=name]').type(this.user.name)
-      cy.get('input[placeholder=email]').type(this.user.email)
-      cy.get('input[placeholder=password]').type(this.user.password)
-      cy.get('input[placeholder="repeat password"]').type(this.user.password)
-
-      cy.get('button').click()
-    })
+    cy.signup(user.name, user.email, user.password)
 
     // Attempt to recreate user.
-    cy.visit('/createuser')
-    cy.get('form').within(function () {
-      cy.get('input[placeholder=name]').type(this.user.name)
-      cy.get('input[placeholder=email]').type(this.user.email)
-      cy.get('input[placeholder=password]').type(this.user.password)
-      cy.get('input[placeholder="repeat password"]').type(this.user.password)
-
-      cy.get('button').click()
-    })
+    cy.signup(user.name, user.email, user.password)
 
     cy.get('form').contains(
       'Email address already in use, Try logging in instead.'
@@ -39,7 +24,7 @@ describe('Create User', () => {
     cy.url().should('eq', Cypress.config().baseUrl + '/createuser')
   })
 
-  it('Creates a new user', () => {
+  it('Creates a new user', function () {
     const randomInt = Math.floor(Math.random() * 10000)
     const newUser = {
       email: `user${randomInt}@polis.test`,
@@ -53,18 +38,12 @@ describe('Create User', () => {
       url: Cypress.config().apiPath + '/auth/new'
     }).as('authNew')
 
-    cy.get('form').within(async function () {
-      cy.get('input[placeholder=name]').type(newUser.name)
-      cy.get('input[placeholder=email]').type(newUser.email)
-      cy.get('input[placeholder=password]').type(newUser.password)
-      cy.get('input[placeholder="repeat password"]').type(newUser.password)
+    cy.signup(newUser.name, newUser.email, newUser.password)
 
-      cy.get('button').click()
-
-      const xhr = await cy.wait('@authNew')
+    cy.wait('@authNew').then((xhr) => {
       expect(xhr.status).to.equal(200)
-
-      cy.url().should('eq', Cypress.config().baseUrl + '/')
     })
+
+    cy.url().should('eq', Cypress.config().baseUrl + '/')
   })
 })

--- a/e2e/cypress/integration/polis/client-admin/home.spec.js
+++ b/e2e/cypress/integration/polis/client-admin/home.spec.js
@@ -1,5 +1,5 @@
 describe('Home Page', () => {
-  beforeEach(() => cy.visit(''))
+  beforeEach(() => cy.visit('/'))
 
   it('bare Url redirects to /home', () => {
     cy.url().should('eq', Cypress.config().baseUrl + '/home')

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -23,3 +23,20 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+Cypress.Commands.add("logout", () => {
+  cy.visit('/signout')
+})
+
+Cypress.Commands.add("signup", (name, email, password) => {
+  cy.visit('/createuser')
+
+  cy.get('form').within(function () {
+    cy.get('input[placeholder=name]').type(name)
+    cy.get('input[placeholder=email]').type(email)
+    cy.get('input[placeholder=password]').type(password)
+    cy.get('input[placeholder="repeat password"]').type(password)
+
+    cy.get('button').click()
+  })
+})


### PR DESCRIPTION
- Added some commands for "signout" and "login"
- Made existing tests more idiomatic (less explicit async funcs)

## Re: Ongoing Testing

Hard to do many more tests on the old UI, since it's missing the element ID's added in #280 rewrite. So after this, going to start writing tests only against the new admin UI.

I'll keep those in a separate feature branch based off of `colinmegill/new-lander-and-upgrds`. That way, we can either PR it into mainline `dev` if #280 lands soon, or PR it into the feature branch `colinmegill/new-lander-and-upgrds` if that code review is taking a bit. (I don't have a sense of how rigorous our review of that massive changeset will be :) )