### PR TITLE
Added CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,9 @@
 /.github/**  @metasoarous
 /server/**   @metasoarous
 /math/**     @metasoarous
-Dockerfile*  @metasoarous
+
+docker-compose.yml @metasoarous @patcon @ballpointpenguin
+Dockerfile*        @metasoarous @patcon @ballpointpenguin
+*.env*             @metasoarous @patcon @ballpointpenguin
+
+/e2e/**            @patcon @ballpointpenguin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# This is used to auto-assign reviewers to pull requests, among other things.
+#
+# Note: Currently only works for users/teams with write access.
+# See: https://help.github.com/en/github/creating-cloning-and-archiving-reposoitories/about-code-owners
+
+*            @pol-is/core @pol-is/community
+
+/client-*/** @colinmegill
+
+/.github/**  @metasoarous
+/server/**   @metasoarous
+/math/**     @metasoarous
+Dockerfile*  @metasoarous


### PR DESCRIPTION
💬 **Chat context:** https://gitter.im/pol-is/polisDeployment?at=5ee2eef35dcbb760b6e4c2b2

@colinmegill's comment made me realize we could codify this a bit. The baked-in `CODEOWNER` feature set is a bit limited, but we can extend it later with existing GitHub apps, if we'd like.

Right now, this will simply auto-request review from people on PRs that touch "their" files. It will only work for users/team with write access on repo, and so only for @colinmegill and @metasoarous for now.

So if a new person opens a PR, it will auto-add these people as reviewers, depending on what the PR changes.