### PR TITLE
Allow subscription alert to be localized/translated

### DIFF
--- a/client-participation/js/strings/en_us.js
+++ b/client-participation/js/strings/en_us.js
@@ -102,6 +102,7 @@ s.notificationsGetNotified = "Get notified when more statements arrive:";
 s.notificationsEnterEmail = "Enter your email address to get notified when more statements arrive:";
 s.labelEmail = "Email";
 s.notificationsSubscribeButton = "Subscribe";
+s.notificationsSubscribeErrorAlert = "Error subscribing";
 s.noCommentsYet = "There aren't any statements yet.";
 s.noCommentsYetSoWrite = "Get this conversation started by adding a statement.";
 s.noCommentsYetSoInvite = "Get this conversation started by inviting more participants, or add a statement.";

--- a/client-participation/js/strings/es_la.js
+++ b/client-participation/js/strings/es_la.js
@@ -93,6 +93,7 @@ s.notificationsGetNotified = "Recibe notificaciones cuando comentarios nuevos ap
 s.notificationsEnterEmail = "Ingrese su dirección de email para recibir notificaciones cuando lleguen más comentarios:";
 s.labelEmail = "Email";
 s.notificationsSubscribeButton = "Subscribe";
+s.notificationsSubscribeErrorAlert = "Error al suscribirse";
 s.noCommentsYet = "Aún no hay comentarios";
 s.noCommentsYetSoWrite = "Agregue un comentario para comenzar esta conversación.";
 s.noCommentsYetSoInvite = "Comience esta conversación - invite más participantes o agregue un comentario.";

--- a/client-participation/js/views/vote-view.js
+++ b/client-participation/js/views/vote-view.js
@@ -468,7 +468,7 @@ module.exports = Handlebones.ModelView.extend({
         that.model.set("foo", Math.random()); // trigger render
         // alert("you have subscribed");
       }, function(err) {
-        alert("Error subscribing");
+        alert(Strings.notificationsSubscribeErrorAlert);
         console.error(err);
       });
       return false;


### PR DESCRIPTION
Re-ticketed from https://github.com/pol-is/polisServer/issues/182#issuecomment-357206470

@virgile-dev how's this look?

@colinmegill can we give it more description about why it's failing? Assuming this only comes up for the case explained in the other issue, then we can probably say something like:

> Subscription error! Is this email already tied to a user account?