### PR TITLE
Fix: Hardcode dev as target-branch for dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,21 +6,24 @@ updates:
 
   - directory: "/client-admin"
     package-ecosystem: "npm"
+    labels: ["dependencies", "🔩 p:client-admin"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
-    labels: ["dependencies", "🔩 p:client-admin"]
 
   - directory: "/file-server"
     package-ecosystem: "npm"
+    labels: ["dependencies"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
-    labels: ["dependencies"]
 
   ## Disabled (until major manual update)
 
   - directory: "/server"
     package-ecosystem: "npm"
     labels: ["dependencies", "🔩 p:server"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     ignore:
@@ -29,6 +32,7 @@ updates:
   - directory: "/client-participation"
     package-ecosystem: "npm"
     labels: ["dependencies", "🔩 p:client-participation"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     ignore:
@@ -37,6 +41,7 @@ updates:
   - directory: "/client-report"
     package-ecosystem: "npm"
     labels: ["dependencies", "🔩 p:client-report"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     ignore:
@@ -47,45 +52,52 @@ updates:
   - directory: "/math"
     package-ecosystem: "docker"
     labels: ["dependencies", "⚒️ infrastructure", "🔩 p:math"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
 
   - directory: "/server"
     package-ecosystem: "docker"
     labels: ["dependencies", "⚒️ infrastructure", "🔩 p:server"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
 
   - directory: "/file-server"
     package-ecosystem: "docker"
     labels: ["dependencies", "⚒️ infrastructure"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
 
   - directory: "/client-admin"
     package-ecosystem: "docker"
     labels: ["dependencies", "⚒️ infrastructure", "🔩 p:client-admin"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
 
   - directory: "/client-participation"
     package-ecosystem: "docker"
     labels: ["dependencies", "⚒️ infrastructure", "🔩 p:client-participation"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
 
   - directory: "/client-report"
     package-ecosystem: "docker"
     labels: ["dependencies", "⚒️ infrastructure", "🔩 p:client-report"]
+    target-branch: "dev"
     schedule:
       interval: "weekly"
 
   # GITHUB ACTIONS external action updates
 
-  - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`
-    directory: "/"
+  - directory: "/"
+    package-ecosystem: "github-actions"
     labels: ["dependencies", "⚒️ infrastructure"]
+    target-branch: "dev"
     schedule:
       interval: "daily"


### PR DESCRIPTION
When doing development of github actions on a fork (like with #320), sometimes the pending feature branch must be set as GitHub's default branch in the fork (in this case, so that an `on: schedule` workflow would get registered to run). Since dependabot config previously had no `target-branch` value set on `updates` entries, Dependabot was falling back to looking on this new default branch for work it needed to do.

This meant that **when my fork changed the default branch to the feature branch, dependabot started openning PRs** against it. This fixes that.

In this PR, hardcoding the `dev` branch means that this would be much less likely to happen. (It admittedly adds some burden to changing the default branch, since Dependabot config must be updated along with the GitHub UI setting.)

EDIT: Dependabot config doesn't yet support YAML aliases, which will hopefully make this whole config file cleaner in the future: https://github.com/dependabot/feedback/issues/591#issuecomment-644675145