### PR TITLE
Add bundlewatch support for monitoring bundle size and changes

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -1,0 +1,67 @@
+name: "Bundlewatch Github Action"
+
+on:
+  push:
+    # Required so that baseline for comparison is pushed to bundlewatch service.
+    branches: ["dev"]
+    # Note: Only configured for client-admin right now.
+    paths:
+      - .github/workflows/bundlewatch.yml
+      - client-admin
+  pull_request:
+    types: ["opened", "reopened", "synchronize"]
+    paths:
+      - .github/workflows/bundlewatch.yml
+      - client-admin
+
+jobs:
+  bundlewatch:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+    - uses: actions/checkout@v2.3.1
+
+    - name: Use Node.js
+      uses: actions/setup-node@v2.0.0
+      with:
+        node-version: 14.4.0
+
+    - name: Get npm cache directory
+      id: npm-cache
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+    - name: Restore npm cache directory
+      uses: actions/cache@v2.0.0
+      with:
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: Install Bundlewatch
+      run: npm install -g bundlewatch@0.2.6
+
+    - name: "Install & Build: client-admin"
+      working-directory: client-admin
+      run: |
+        npm install
+        npm run build:webpack
+
+    - name: Run Bundlewatch
+      # TODO: Move config to root directory, so easier to run against all components.
+      # See: https://github.com/bundlewatch/bundlewatch/pull/170
+      working-directory: client-admin
+      env:
+        CI_BRANCH_DEFAULT: ${{ github.event.repository.default_branch }}
+
+        PR_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        # Overrides `ci.repoBranchBase` (bundlewatch config)
+        PR_BRANCH_BASE: ${{ github.event.pull_request.base.ref }}
+
+        PUSH_COMMIT_SHA: ${{ github.event.after }}
+        PUSH_BRANCH: ${{ env.GITHUB_REF }}
+        PUSH_BRANCH_BASE: ${{ github.event.repository.default_branch }}
+      run: npx bundlewatch --config .bundlewatch.config.js

--- a/client-admin/.bundlewatch.config.js
+++ b/client-admin/.bundlewatch.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  "ci": {
+    "trackBranches": [
+      process.env.CI_BRANCH_DEFAULT,
+    ],
+    // Allows bundlewatch GitHub Actions workflow to work on: pull_request, or push
+    "commitSha": process.env.PR_COMMIT_SHA || process.env.PUSH_COMMIT_SHA,
+    "repoBranchBase": process.env.PR_BRANCH_BASE || process.env.PUSH_BRANCH_BASE,
+    "repoCurrentBranch": process.env.PR_BRANCH || process.env.PUSH_BRANCH,
+  },
+  "files": [
+    {
+      "path": "dist/*.js",
+      "maxSize": "500 kB",
+    },
+  ]
+};

--- a/client-participation/Dockerfile
+++ b/client-participation/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 RUN apk add --no-cache --virtual .build \
   g++ git make python
 
+RUN npm config set unsafe-perm true
 RUN npm install -g bower
 
 COPY package*.json ./


### PR DESCRIPTION
Resolves https://github.com/pol-is/polisServer/issues/256

You'll see an example of how this check looks on this PR itself, but it will lack the "size diff from mainline" feature, since we haven't yet run on mainline to compare against, so the service lacks data. To see an example of this comparison feature, see: https://github.com/patcon/polisServer/pull/30#partial-pull-merging

This is currently just for `client-admin`. Adding it for more client-* components seems doable, but requires more effort andm maybe this bugfix: https://github.com/bundlewatch/bundlewatch/pull/170 (I'd recommedn just merging this, and start getting benefit now, and expand coverage later :) )