### PR TITLE
Fix e2e tests

### DIFF
--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -65,5 +65,11 @@ Cypress.Commands.add("createConvo", (adminEmail, adminPassword) => {
   cy.login(adminEmail, adminPassword)
   cy.visit('/')
 
+  cy.server()
+  cy.route('GET', Cypress.config().apiPath + '/conversations**')
+    .as('getNewConvo')
+
   cy.get('button').contains('Create new conversation').click()
+
+  cy.wait('@getNewConvo').its('status').should('eq', 200)
 })


### PR DESCRIPTION
e2e tests broke, as seen in recent comments: https://github.com/pol-is/polisServer/commits/dev

When we merged some new tests in a PR, some reorganization around creating conversations seems to be a bit fragile, as so the test tries to "save" the path before the page has redirected to the new convo. This should hopefully fix it.