### PR TITLE
update deployment instructions in docs/deployment.md and READMEs

### DIFF
--- a/client-admin/README.md
+++ b/client-admin/README.md
@@ -3,6 +3,10 @@
 Polis Admin Console
 ===================
 
+The below instructions are no longer officially supported; if you'd like to use them as a reference, we suggest you check out the official [Dockerfile](Dockerfile) to understand the latest build process and specific package versions.
+
+---
+
 Configuration
 -------------
 

--- a/client-participation/README.md
+++ b/client-participation/README.md
@@ -7,6 +7,10 @@ This is the code for the view that conversation participants see.
 Development
 -----------
 
+The below instructions are no longer officially supported; if you'd like to use them as a reference, we suggest you check out the official [Dockerfile](Dockerfile) to understand the latest build process and specific package versions.
+
+---
+
 Install with [npm](https://www.npmsjs.org/) and [bower](http://bower.io/) (`npm install --global bower`):
 
 ```sh

--- a/client-report/README.md
+++ b/client-report/README.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+The below instructions are no longer officially supported; if you'd like to use them as a reference, we suggest you check out the official [Dockerfile](Dockerfile) to understand the latest build process and specific package versions.
+
+---
+
 Same environment variables as the rest of the apps.
 Once you have the npm modules set up (`npm install`?), you can run the development server (with hot code reloading) by running `./x`.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,7 +12,7 @@ First things first, it helps to understand a bit how the system is set up.
 | [`math`][dir-math] | Clojure/JVM | The math engine.  |
 | [`client-participation`][dir-participation] | Javascript | The client code for end-users. |
 | [`client-admin`][dir-admin] | Javascript | The client code for administrators. |
-| [`report`][dir-report] | Node.js | The code for detailed analytics reports. |
+| [`client-report`][dir-report] | Node.js | The code for detailed analytics reports. |
 
 The code in the two client-side repos compile to static assets.
 We push these to s3 for CDN via `deployPreprod` and `deploy_TO_PRODUCTION`, but there is a config file for each of these projects which will allow you to configure the behavior of these scripts as described in the READMEs.
@@ -23,7 +23,7 @@ Finally, for local development, these repos have hot-reload able servers you can
    [dir-math]: /math
    [dir-participation]: /client-participation
    [dir-admin]: /client-admin
-   [dir-report]: /report
+   [dir-report]: /client-report
 
 ### Environment variables and configuration
 
@@ -59,7 +59,7 @@ TODO Compile complete starter template somewhere in this repo...
 3) Build client repo assets using the instructions in the respective Readmes:
    * [`/client-participation`][dir-participation]
    * [`/client-admin`][dir-admin]
-   * [`/report`][dir-report]
+   * [`/client-report`][dir-report]
 4) Each of the above repos also contains instructions for running a server with HMR; By default, the server should forward requests for these compiled assets to the HMR server.
 
 ## Basic/Manual deployment

--- a/math/README.md
+++ b/math/README.md
@@ -5,6 +5,10 @@ The machine learning and data flow system powering pol.is.
 
 ## Setup
 
+The below instructions are no longer officially supported; if you'd like to use them as a reference, we suggest you check out the official [Dockerfile](Dockerfile) to understand the latest build process and specific package versions.
+
+---
+
 To get running, you'll need to [install Leinengen](https://github.com/technomancy/leiningen) (v at least 2.0).
 From there, all clojure dependencies can be installed using `lein deps`.
 However, you'll also need the postgresql (client) installed (sudo `apt-get install postgresql postgresql-client` on ubuntu).

--- a/server/README.md
+++ b/server/README.md
@@ -6,6 +6,10 @@ Polis [can be easily embedded](http://docs.pol.is/usage/Embedding.html) on your 
 
 ## Installation
 
+The below instructions are no longer officially supported; if you'd like to use them as a reference, we suggest you check out the official [Dockerfile](Dockerfile) to understand the latest build process and specific package versions.
+
+---
+
 ### Dependencies
 
 * PostgreSql `(>= 9.5.4.1)`
@@ -53,7 +57,7 @@ We recommend installing [nvm](https://github.com/creationix/nvm) so you can easi
     ```sh
     $ ./x
     ```
-1. In another shell, start the [polisClientAdmin](https://github.com/pol-is/polisClientAdmin). Follow installation directions on the project README.
+1. In another shell, start the [client-admin](../client-admin). Follow installation directions on the component README.
     ```
     $ ./x
     ```

--- a/server/app.js
+++ b/server/app.js
@@ -3,11 +3,8 @@
 
 const Promise = require('bluebird');
 const express = require('express');
-const optional = require("optional");
 
 const server = require('./server');
-
-const polisServerBrand = optional('polisServerBrand');
 
 const app = express();
 
@@ -1286,10 +1283,6 @@ helpersInitialized.then(function(o) {
       need('durs', getArrayOfInt, assignToP),
       need('clientTimestamp', getInt, assignToP),
       handle_POST_metrics);
-
-  if (polisServerBrand && polisServerBrand.registerRoutes) {
-    polisServerBrand.registerRoutes(app, o);
-  }
 
   function makeFetchIndexWithoutPreloadData() {
     let port = portForParticipationFiles;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3551,11 +3551,6 @@
         }
       }
     },
-    "optional": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
-      "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw=="
-    },
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -39,7 +39,6 @@
     "mimelib": "0.2.19",
     "oauth": "0.9.14",
     "optimist": "0.3.7",
-    "optional": "^0.1.3",
     "p3p": "0.0.2",
     "pg": "7.4.3",
     "pg-connection-string": "2.0.0",
@@ -55,8 +54,5 @@
     "underscore": "1.8.3",
     "valid-url": "1.0.9",
     "winston": "1.0.2"
-  },
-  "optionalDependencies": {
-    "polisServerBrand": "git+https://github.com/colinmegill/polisServerBrand.git#master"
   }
 }


### PR DESCRIPTION
1. Update link to client-report component
2. Add note about referring to relevant Dockerfile for correct package versions.
3. Remove an optionalDependency of server/package.json that doesn't seem to exist on github anymore