### PR TITLE
Show permission error for admin UI when not moderator

### DIFF
--- a/client-admin/src/components/conversation-admin/data-export.js
+++ b/client-admin/src/components/conversation-admin/data-export.js
@@ -1,5 +1,7 @@
 // Copyright (C) 2012-present, The Authors. This program is free software: you can redistribute it and/or  modify it under the terms of the GNU Affero General Public License, version 3, as published by the Free Software Foundation. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import ComponentHelpers from "../../util/component-helpers";
+import NoPermission from "./no-permission";
 import React from "react";
 import { connect } from "react-redux";
 import { startDataExport } from "../../actions";
@@ -50,6 +52,10 @@ class DataExport extends React.Component {
     this.setState({ untilEnabled: !this.state.untilEnabled });
   }
   render() {
+    if (ComponentHelpers.shouldShowPermissionsError(this.props)) {
+      return <NoPermission />;
+    }
+
     return (
       <div>
         <Heading

--- a/client-admin/src/components/conversation-admin/no-permission.js
+++ b/client-admin/src/components/conversation-admin/no-permission.js
@@ -6,7 +6,7 @@ import strings from "../../strings/strings";
 class NoPermission extends React.Component {
   render() {
     return (
-      <div>
+      <div id="no-permission-warning">
         <div>{strings("no_permission")}</div>
       </div>
     );

--- a/client-admin/src/components/conversation-admin/report/reports-list.js
+++ b/client-admin/src/components/conversation-admin/report/reports-list.js
@@ -1,5 +1,7 @@
 // Copyright (C) 2012-present, The Authors. This program is free software: you can redistribute it and/or  modify it under the terms of the GNU Affero General Public License, version 3, as published by the Free Software Foundation. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details. You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import ComponentHelpers from "../../../util/component-helpers";
+import NoPermission from "../no-permission";
 import PolisNet from "../../../util/net";
 import React from "react";
 import { connect } from "react-redux";
@@ -42,6 +44,10 @@ class ReportsList extends React.Component {
   }
 
   render() {
+    if (ComponentHelpers.shouldShowPermissionsError(this.props)) {
+      return <NoPermission />;
+    }
+
     if (this.state.loading) {
       return <div>Loading Reports...</div>;
     }

--- a/client-admin/src/components/conversation-admin/report/reports-list.js
+++ b/client-admin/src/components/conversation-admin/report/reports-list.js
@@ -31,7 +31,11 @@ class ReportsList extends React.Component {
   }
 
   componentWillMount() {
-    this.getData();
+    const { zid_metadata } = this.props;
+
+    if (zid_metadata.is_mod) {
+      this.getData();
+    }
   }
 
   createReportClicked() {

--- a/client-admin/src/components/conversation-admin/share-and-embed.js
+++ b/client-admin/src/components/conversation-admin/share-and-embed.js
@@ -2,6 +2,8 @@
 
 import ConversationHasCommentsCheck from "./conversation-has-comments-check";
 import React from "react";
+import ComponentHelpers from "../../util/component-helpers";
+import NoPermission from "./no-permission";
 import Url from "../../util/url";
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
@@ -20,6 +22,10 @@ class ShareAndEmbed extends React.Component {
     );
   }
   render() {
+    if (ComponentHelpers.shouldShowPermissionsError(this.props)) {
+      return <NoPermission />;
+    }
+
     const { match } = this.props;
     return (
       <div>

--- a/client-admin/src/components/conversation-admin/stats/index.js
+++ b/client-admin/src/components/conversation-admin/stats/index.js
@@ -47,13 +47,21 @@ class ConversationStats extends React.Component {
     this.props.dispatch(populateConversationStatsStore(match.params.conversation_id, until));
   }
   componentWillMount() {
-    this.loadStats();
-    this.getStatsRepeatedly = setInterval(() => {
+    const { zid_metadata } = this.props;
+
+    if (zid_metadata.is_mod) {
       this.loadStats();
-    }, 10000);
+      this.getStatsRepeatedly = setInterval(() => {
+        this.loadStats();
+      }, 10000);
+    }
   }
   componentWillUnmount() {
-    clearInterval(this.getStatsRepeatedly);
+    const { zid_metadata } = this.props;
+
+    if (zid_metadata.is_mod) {
+      clearInterval(this.getStatsRepeatedly);
+    }
   }
 
   render() {

--- a/client-admin/src/components/conversation-admin/stats/index.js
+++ b/client-admin/src/components/conversation-admin/stats/index.js
@@ -3,6 +3,8 @@
 
 import dateSetupUtil from "../../../util/data-export-date-setup";
 import React from "react";
+import ComponentHelpers from "../../../util/component-helpers";
+import NoPermission from "../no-permission";
 import { connect } from "react-redux";
 import { populateConversationStatsStore } from "../../../actions";
 import NumberCards from "./conversation-stats-number-cards";
@@ -10,6 +12,7 @@ import Voters from "./voters";
 import Commenters from "./commenters";
 import { Heading, Box, jsx } from "theme-ui";
 
+@connect((state) => state.zid_metadata)
 @connect((state) => state.stats)
 class ConversationStats extends React.Component {
   constructor(props) {
@@ -54,6 +57,10 @@ class ConversationStats extends React.Component {
   }
 
   render() {
+    if (ComponentHelpers.shouldShowPermissionsError(this.props)) {
+      return <NoPermission />;
+    }
+
     const { conversation_stats } = this.props;
     const loading = !conversation_stats.firstCommentTimes || !conversation_stats.firstVoteTimes;
 

--- a/client-admin/src/util/component-helpers.js
+++ b/client-admin/src/util/component-helpers.js
@@ -3,8 +3,7 @@
 const helpers = {};
 
 helpers.shouldShowPermissionsError = (props) => {
-  return false;
-  //return props.zid_metadata && !props.zid_metadata.is_owner && !props.zid_metadata.is_mod;
+  return props.zid_metadata && !props.zid_metadata.is_owner && !props.zid_metadata.is_mod;
 };
 
 

--- a/e2e/cypress/fixtures/users.json
+++ b/e2e/cypress/fixtures/users.json
@@ -1,7 +1,12 @@
-[
-  {
-    "name": "Test User 0001",
-    "email": "user0001@polis.test",
+{
+  "moderator": {
+    "name": "Dummy Moderator",
+    "email": "moderator@polis.test",
+    "password": "testpassword"
+  },
+  "participant": {
+    "name": "Dummy Participant",
+    "email": "participant@polis.test",
     "password": "testpassword"
   }
-]
+}

--- a/e2e/cypress/integration/polis/client-admin/convo_access.spec.js
+++ b/e2e/cypress/integration/polis/client-admin/convo_access.spec.js
@@ -1,0 +1,46 @@
+describe('Access control', () => {
+  before(() => {
+    cy.fixture('users.json').then((users) => {
+      const user = users.moderator
+      cy.createConvo(user.email, user.password)
+    })
+    cy.location('pathname').as('adminPath')
+  })
+
+  beforeEach(() => {
+    cy.fixture('users.json').then((users) => {
+      const user = users.participant
+      cy.login(user.email, user.password)
+    })
+  })
+
+  it('Cannot access /m/:id', function () {
+    cy.visit(this.adminPath)
+    cy.get('#no-permission-warning').should('exist').and('be.visible')
+  })
+
+  it('Cannot access /m/:id/share', function () {
+    cy.visit(this.adminPath + '/share')
+    cy.get('#no-permission-warning').should('exist').and('be.visible')
+  })
+
+  it('Cannot access /m/:id/comments', function () {
+    cy.visit(this.adminPath + '/comments')
+    cy.get('#no-permission-warning').should('exist').and('be.visible')
+  })
+
+  it('Cannot access /m/:id/comments/rejected', function () {
+    cy.visit(this.adminPath + '/comments/rejected')
+    cy.get('#no-permission-warning').should('exist').and('be.visible')
+  })
+
+  it('Cannot access /m/:id/stats', function () {
+    cy.visit(this.adminPath + '/stats')
+    cy.get('#no-permission-warning').should('exist').and('be.visible')
+  })
+
+  it('Cannot access /m/:id/reports', function () {
+    cy.visit(this.adminPath + '/reports')
+    cy.get('#no-permission-warning').should('exist').and('be.visible')
+  })
+})

--- a/e2e/cypress/integration/polis/client-admin/create_user.spec.js
+++ b/e2e/cypress/integration/polis/client-admin/create_user.spec.js
@@ -10,7 +10,7 @@ describe('Create User', () => {
   })
 
   it('Does not create a new user with existing email address', function () {
-    const user = this.users[0]
+    const user = this.users.moderator
 
     // Attempt to recreate existing user.
     cy.signup(user.name, user.email, user.password)

--- a/e2e/cypress/integration/polis/client-admin/routes.spec.js
+++ b/e2e/cypress/integration/polis/client-admin/routes.spec.js
@@ -1,7 +1,7 @@
 describe('Routes', () => {
   before(() => {
     cy.fixture('users.json').then((users) => {
-      const user = users[0]
+      const user = users.moderator
       cy.createConvo(user.email, user.password)
     })
     cy.location('pathname').as('adminPath')
@@ -9,7 +9,7 @@ describe('Routes', () => {
 
   beforeEach(() => {
     cy.fixture('users.json').then((users) => {
-      const user = users[0]
+      const user = users.moderator
       cy.login(user.email, user.password)
     })
   })

--- a/e2e/cypress/integration/polis/client-participation/i18n.spec.js
+++ b/e2e/cypress/integration/polis/client-participation/i18n.spec.js
@@ -8,7 +8,7 @@ describe('Interface internationalization', () => {
 
   before(() => {
     cy.fixture('users.json').then((users) => {
-      const user = users[0]
+      const user = users.moderator
       cy.createConvo(user.email, user.password)
       cy.location('pathname').then((adminPath) => {
         const convoPath = adminPath.replace('/m/', '/')

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -25,7 +25,13 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 Cypress.Commands.add("logout", () => {
+  cy.server()
+  cy.route('POST', Cypress.config().apiPath + '/auth/deregister')
+    .as('authLogout')
+
   cy.visit('/signout')
+
+  cy.wait('@authLogout').its('status').should('eq', 200)
 })
 
 Cypress.Commands.add("signup", (name, email, password) => {

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -23,7 +23,8 @@ before(() => {
   cy.fixture('users.json').then((users) => {
     // Ensure a default user is present for each spec.
     // TODO: Move this into a true database seeding process.
-    const user = users[0]
-    cy.signup(user.name, user.email, user.password)
+    for (let [type, user] of Object.entries(users)) {
+      cy.signup(user.name, user.email, user.password)
+    }
   })
 })

--- a/server/server.js
+++ b/server/server.js
@@ -9750,6 +9750,8 @@ Email verified! You can close this tab or hit the back button.
               return;
             }
             let conv = result && result.rows && result.rows[0];
+            // The first check with isModerator implictly tells us this can be returned in HTTP response.
+            conv.is_mod = true;
 
             let promise = generateShortUrl ?
               generateAndReplaceZinvite(req.p.zid, generateShortUrl) :


### PR DESCRIPTION
Resolves #359 

## To Do

- [x] prevent rendering of admin UI when without moderator perms
- [x] add NoPermission component on other admin pages:
  - [x] `/m/:convo_id/share`
  - [x] `/m/:convo_id/stats`
  - [x] `/m/:convo_id/reports`
- [x] prevent 4xx requests on NoPermission pages
- [x] add e2e tests