### PR TITLE
Ignore example test files

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,7 +23,7 @@ To run these tests:
 - The default base url for running tests against, is https://localhist
   - You may override any cypress-related command this like so: `CYPRESS_BASE_URL=http://123.45.67.89.xip.io npm test`
 - `cypress/integration/polis/`: where we store our tests
-- `cypress/integration/examples`: where we store boilerplate examples
+- `cypress/integration/examples`: where we store boilerplate examples (ignored by test runner)
 - `cypress/support/commands.js`: where we keep oft-used commands, e.g., for logging in, creating conversations, etc.
 - `cypress/support/index.js`: where we keep code we wish to run during initial setup, e.g., to ensure default users present.
 - For tests against features that require third-party credentials when self-hosted, we use filenames like `*.secrets.spec.js`.

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,4 +1,5 @@
 {
   "apiPath": "/api/v3",
+  "ignoreTestFiles": "**/examples/*.spec.js",
   "baseUrl": "http://localhost"
 }


### PR DESCRIPTION
Re-ticketed from #441 

Only adding config via `cypress.json` (or envvar or CLI arg) allowed config to be respected in visual test runner UI, and `cypress.json` seemed best place. (neither `support/index.js` nor `plugins/index.js` worked for UI)