### PR TITLE
Use version instead of url for file-loader package

### DIFF
--- a/client-admin/package-lock.json
+++ b/client-admin/package-lock.json
@@ -7440,6 +7440,12 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "escalade": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
+      "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+      "dev": true
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -8620,7 +8626,8 @@
       }
     },
     "file-loader": {
-      "version": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
       "integrity": "sha512-yDylQzd/QOaMm249awSL+JjsLRDfFghwmm+YCALH0uLXqAazD/alHnhbIE+UyVtbI+bIVYVdgDApSJ9blouFDg==",
       "dev": true,
       "requires": {

--- a/client-admin/package.json
+++ b/client-admin/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-standard": "^4.0.1",
     "express": "^4.13.3",
-    "file-loader": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
+    "file-loader": "0.8.5",
     "glob": "^7.1.2",
     "gulp": "^3.9.0",
     "gulp-cli": "^1.4.0",


### PR DESCRIPTION
Not sure why this was being done before.

This changes nothing but allows update tools (dependabot, npm-audit, npm-outdated) to manage the package.

This is a no-op -- just an infra level change.