### PR TITLE
Lower admin bundlesize limit to 250kB as recommended [skip ci]

### DIFF
--- a/client-admin/.bundlewatch.config.js
+++ b/client-admin/.bundlewatch.config.js
@@ -11,7 +11,7 @@ module.exports = {
   "files": [
     {
       "path": "dist/*.js",
-      "maxSize": "500 kB",
+      "maxSize": "250 kB",
     },
   ]
 };


### PR DESCRIPTION
This is what webpack recommends. This will fail our build if it goes above. (We're currently quite a bit below, at 211 kB)

https://webpack.js.org/configuration/performance/#performance