### PR TITLE
It is not possible to allow users to only use one of facebook / twitter to vote.

### DIFF
--- a/client-participation/js/templates/comment-form.handlebars
+++ b/client-participation/js/templates/comment-form.handlebars
@@ -159,6 +159,7 @@
         margin-top: 10px;
         ">
       <div class="protip"><p><i class="fa fa-microphone"></i>&nbsp; {{s.connectToPostPrompt}}</p></div>
+      {{#if auth_opt_fb}}
       {{#unless hasFacebook}}
         <button id="facebookButtonCommentForm" class="facebookButton" style="padding-top: 0px;">
           <i class="svgIcon" style="
@@ -171,6 +172,8 @@
           ">{{> iconFaFacebookSquare25}}</i>
           {{s.connectFacebook}}</button>
       {{/unless}}
+      {{/if}}
+      {{#if auth_opt_tw}}
       {{#unless hasTwitter}}
         <button id="twitterButtonCommentForm" class="twitterButton" style="padding-top: 0px;">
         <i class="svgIcon" style="
@@ -183,6 +186,7 @@
         ">{{> iconFaTwitter25}}</i>
           {{s.connectTwitter}}</button>
       {{/unless}}
+      {{/if}}
     </div>
 
     {{!-- ================ LOWER CONTAINER ================ --}}

--- a/client-participation/js/templates/vote-view.handlebars
+++ b/client-participation/js/templates/vote-view.handlebars
@@ -12,6 +12,7 @@
     margin: 10px;
     ">
   <div class="protip"><p><i class="fa fa-microphone"></i>&nbsp; {{s.connectToVotePrompt}}</p></div>
+  {{#if auth_opt_fb}}
   {{#unless hasFacebook}}
     <button id="facebookButtonVoteView" class="facebookButton" style="padding-top: 0px; margin-bottom: 4px;">
       <i class="svgIcon" style="
@@ -24,6 +25,8 @@
       ">{{> iconFaFacebookSquare25}}</i>
       {{s.connectFacebook}}</button>
   {{/unless}}
+  {{/if}}
+  {{#if auth_opt_tw}}
   {{#unless hasTwitter}}
     <button id="twitterButtonVoteView" class="twitterButton" style="padding-top: 0px; margin-bottom: 4px;">
     <i class="svgIcon" style="
@@ -36,6 +39,7 @@
     ">{{> iconFaTwitter25}}</i>
       {{s.connectTwitter}}</button>
   {{/unless}}
+  {{/if}}
 </div>
 
 {{else}}  {{!-- !needSocial --}}

--- a/client-participation/js/views/comment-form.js
+++ b/client-participation/js/views/comment-form.js
@@ -42,6 +42,8 @@ module.exports = Handlebones.ModelView.extend({
     ctx.shouldAutofocusOnTextarea = this.shouldAutofocusOnTextarea || Utils.shouldFocusOnTextareaWhenWritePaneShown();
     ctx.hasTwitter = userObject.hasTwitter;
     ctx.hasFacebook = userObject.hasFacebook;
+    ctx.auth_opt_tw = preload.firstConv.auth_opt_tw;
+    ctx.auth_opt_fb = preload.firstConv.auth_opt_fb;
     ctx.s = Strings;
     ctx.desktop = !display.xs();
     ctx.hideHelp = !Utils.userCanSeeHelp() || preload.firstConv.help_type === 0;

--- a/client-participation/js/views/vote-view.js
+++ b/client-participation/js/views/vote-view.js
@@ -66,6 +66,8 @@ module.exports = Handlebones.ModelView.extend({
       ctx.customBtnStyles = "background-color: " + btnBg + ";";
     }
 
+    ctx.auth_opt_tw = preload.firstConv.auth_opt_tw;
+    ctx.auth_opt_fb = preload.firstConv.auth_opt_fb;
     var social = ctx.social;
     var socialCtx = {
       name: Strings.anonPerson,


### PR DESCRIPTION
Steps to reproduce:
- Create a new conversation.
- Check [Participants cannot vote without first connecting either Facebook or Twitter]
- Check [Show Facebook login prompt]
- Uncheck [Show Twitter login prompt]
- Go to the conversation link as an unlogged in user.
- Try to vote

Expected result:
-  Only [Connect with Facebook] button is shown.

What happens instead:
-  Both [Connect with Facebook] and [Connect with Twitter] buttons are shown.
