### PR TITLE
Allow local polis.config.js to take precedence over template

### DIFF
--- a/client-admin/Dockerfile
+++ b/client-admin/Dockerfile
@@ -8,8 +8,9 @@ RUN apk add git --no-cache
 COPY package*.json ./
 RUN npm install
 
-COPY . .
 COPY polis.config.template.js polis.config.js
+# If polis.config.js exists on host, will override template here.
+COPY . .
 
 ARG GIT_HASH
 RUN npm run build:preprod

--- a/client-participation/Dockerfile
+++ b/client-participation/Dockerfile
@@ -17,8 +17,9 @@ RUN bower install --allow-root
 
 RUN apk del .build
 
-COPY . .
 COPY polis.config.template.js polis.config.js
+# If polis.config.js exists on host, will override template here.
+COPY . .
 
 ARG GIT_HASH
 RUN npm run build:preprod

--- a/client-report/Dockerfile
+++ b/client-report/Dockerfile
@@ -8,8 +8,9 @@ RUN apk add git --no-cache
 COPY package*.json ./
 RUN npm ci
 
-COPY . .
 COPY polis.config.template.js polis.config.js
+# If polis.config.js exists on host, will override template here.
+COPY . .
 
 ARG GIT_HASH
 RUN npm run build:preprod


### PR DESCRIPTION
I'm working on getting some tests going for Facebook login, and it feels quite odd that I need to keep `client-*/polis.config.template.js` modified (dirtying the workspace) in order to customize the container build.

This is a commit to revert back to something we used to have, where `polis.config.template.js` is only used in a container build if a custom file doesn't already exist.

cc @ballPointPenguin because I recall you had some concern with this before?