### PR TITLE
Test e2e workflow against a test domain instead of localhost

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -31,6 +31,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Add test host to /etc/hosts
+        run: echo "127.0.0.1 polis.test" | sudo tee -a /etc/hosts
+
       - name: Checkout
         uses: actions/checkout@v2.3.2
 
@@ -65,7 +68,7 @@ jobs:
       - name: "Run Cypress tests: default"
         uses: cypress-io/github-action@v1
         env:
-          CYPRESS_BASE_URL: https://localhost
+          CYPRESS_BASE_URL: https://polis.test
         with:
           working-directory: ./e2e
           # Ignore all tests with pattern *.secrets.spec.js
@@ -76,7 +79,7 @@ jobs:
         if: env.DO_COMMENT_TRANSLATION
         uses: cypress-io/github-action@v1
         env:
-          CYPRESS_BASE_URL: https://localhost
+          CYPRESS_BASE_URL: https://polis.test
         with:
           install: false
           working-directory: ./e2e


### PR DESCRIPTION
We've been testing against localhost in the cypress e2e test workflow. *.xip.io also works locally for all the tests.

There are some special-cases for localhost, so I think we'll get more robust testing if we edit the `/etc/hosts` to fake a domain.

Related: https://github.com/pol-is/polis/issues/551