### PR TITLE
Minimal all-contributor usage [skip ci]

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -120,6 +120,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ricardopoppi",
+      "name": "Ricardo Poppi",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/1162183?v=4",
+      "profile": "https://github.com/ricardopoppi",
+      "contributions": [
+        "translation"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -239,6 +239,15 @@
         "doc",
         "code"
       ]
+    },
+    {
+      "login": "bamstam",
+      "name": "Bamstam",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/9203888?v=4",
+      "profile": "https://github.com/bamstam",
+      "contributions": [
+        "translation"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -175,6 +175,15 @@
         "doc",
         "infra"
       ]
+    },
+    {
+      "login": "joenio",
+      "name": "Joenio Costa",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/44172?v=4",
+      "profile": "http://joenio.me/",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -202,6 +202,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "patrickas",
+      "name": "Patrick Abi Salloum",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/264735?v=4",
+      "profile": "https://github.com/patrickas",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -30,6 +30,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "metasoarous",
+      "name": "Christopher Small",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/88556?v=4",
+      "profile": "http://www.metasoarous.com/",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -165,6 +165,16 @@
       "contributions": [
         "translation"
       ]
+    },
+    {
+      "login": "vital-edu",
+      "name": "Eduardo Vital Alencar Cunha",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/5282301?v=4",
+      "profile": "https://linktr.ee/vital.edu",
+      "contributions": [
+        "doc",
+        "infra"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -138,6 +138,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "huulbaek",
+      "name": "Thomas Huulbæk Titanium",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1862741?v=4",
+      "profile": "https://github.com/huulbaek",
+      "contributions": [
+        "translation"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -57,6 +57,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ballPointPenguin",
+      "name": "Benjamin Rosas",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/35609?v=4",
+      "profile": "https://sudo-science.com/",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -229,6 +229,16 @@
       "contributions": [
         "translation"
       ]
+    },
+    {
+      "login": "devvmh",
+      "name": "Devin Howard",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/1393708?v=4",
+      "profile": "https://twitter.com/devvmh",
+      "contributions": [
+        "doc",
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -211,6 +211,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "joshsmith2",
+      "name": "Josh Smith",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/3437989?v=4",
+      "profile": "https://github.com/joshsmith2",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -66,6 +66,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "urakagi",
+      "name": "蔡仲明 (Romulus Urakagi Tsai)",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/2368060?v=4",
+      "profile": "http://sais.tw/",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -220,6 +220,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "drewhart",
+      "name": "Drew Hart",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/6105510?v=4",
+      "profile": "https://github.com/drewhart",
+      "contributions": [
+        "translation"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -75,6 +75,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "light24bulbs",
+      "name": "light24bulbs",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/581906?v=4",
+      "profile": "https://github.com/light24bulbs",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -129,6 +129,15 @@
       "contributions": [
         "translation"
       ]
+    },
+    {
+      "login": "willcohen",
+      "name": "Will Cohen",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/5185341?v=4",
+      "profile": "https://github.com/willcohen",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -39,6 +39,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "patcon",
+      "name": "Patrick Connolly",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/305339?v=4",
+      "profile": "http://nodescription.net/",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,25 @@
+{
+  "projectName": "polis",
+  "projectOwner": "pol-is",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "types": {},
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "none",
+  "contributorsSortAlphabetically": true,
+  "contributors": [
+    {
+      "login": "mbjorkegren",
+      "name": "mbjorkegren",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/2016166?v=4",
+      "profile": "https://github.com/mbjorkegren",
+      "contributions": [
+        "code"
+      ]
+    }
+  ]
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -21,6 +21,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "colinmegill",
+      "name": "Colin Megill",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/1770265?v=4",
+      "profile": "https://pol.is/",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -111,6 +111,15 @@
       "contributions": [
         "infra"
       ]
+    },
+    {
+      "login": "crkrenn",
+      "name": "crkrenn",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/6069975?v=4",
+      "profile": "https://github.com/crkrenn",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -93,6 +93,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "virgile-dev",
+      "name": "virgile-dev",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/11473995?v=4",
+      "profile": "http://virgile-dev.github.io/",
+      "contributions": [
+        "translation"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -48,6 +48,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "misscs",
+      "name": "cs",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/51812?v=4",
+      "profile": "https://github.com/misscs",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -84,6 +84,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "kenwheeler",
+      "name": "Ken Wheeler",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/286616?v=4",
+      "profile": "http://kenwheeler.github.io/",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -156,6 +156,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ajsmitha7",
+      "name": "Andrew Smith",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/8118319?v=4",
+      "profile": "https://github.com/ajsmitha7",
+      "contributions": [
+        "translation"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -147,6 +147,15 @@
       "contributions": [
         "translation"
       ]
+    },
+    {
+      "login": "audreyt",
+      "name": "唐鳳",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/20723?v=4",
+      "profile": "http://www.linkedin.com/in/tangaudrey",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -193,6 +193,15 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login": "riley",
+      "name": "Riley Davis",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/282503?v=4",
+      "profile": "http://rileydav.is/",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -102,6 +102,15 @@
       "contributions": [
         "translation"
       ]
+    },
+    {
+      "login": "rohanrichards",
+      "name": "Rohan Richards",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16222002?v=4",
+      "profile": "https://github.com/rohanrichards",
+      "contributions": [
+        "infra"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -184,6 +184,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "DylanGuedes",
+      "name": "Dylan Guedes",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/7079397?v=4",
+      "profile": "http://dylanguedes.github.io/",
+      "contributions": [
+        "test"
+      ]
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -11,6 +11,7 @@
   "commit": true,
   "commitConvention": "none",
   "contributorsSortAlphabetically": true,
+  "contributorTemplate": "<a href='<%= contributor.profile %>'><img src='<%= contributor.avatar_url %>?s=<%= options.imageSize %>' width='<%= options.imageSize %>px;' alt=''/><br /><sub><b><%= contributor.name %></b></sub></a>",
   "contributors": [
     {
       "login": "mbjorkegren",

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
+    <td align="center"><a href='https://sudo-science.com/'><img src='https://avatars0.githubusercontent.com/u/35609?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Benjamin Rosas</b></sub></a></td>
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
+    <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
-    <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
+    <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
+    <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
+    <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -124,19 +124,20 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
     <td align="center"><a href='https://linktr.ee/vital.edu'><img src='https://avatars0.githubusercontent.com/u/5282301?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Eduardo Vital Alencar Cunha</b></sub></a></td>
+    <td align="center"><a href='http://joenio.me/'><img src='https://avatars0.githubusercontent.com/u/44172?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Joenio Costa</b></sub></a></td>
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
-    <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
     <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
     <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
-    <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
     <td align="center"><a href='http://www.linkedin.com/in/tangaudrey'><img src='https://avatars1.githubusercontent.com/u/20723?v=4?s=100' width='100px;' alt=''/><br /><sub><b>唐鳳</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -129,20 +129,23 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
+    <td align="center"><a href='https://github.com/patrickas'><img src='https://avatars2.githubusercontent.com/u/264735?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Abi Salloum</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
     <td align="center"><a href='http://rileydav.is/'><img src='https://avatars0.githubusercontent.com/u/282503?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Riley Davis</b></sub></a></td>
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
     <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
-    <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
     <td align="center"><a href='http://www.linkedin.com/in/tangaudrey'><img src='https://avatars1.githubusercontent.com/u/20723?v=4?s=100' width='100px;' alt=''/><br /><sub><b>唐鳳</b></sub></a></td>
+  </tr>
+  <tr>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
+    <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
-    <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -123,20 +123,21 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='https://sudo-science.com/'><img src='https://avatars0.githubusercontent.com/u/35609?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Benjamin Rosas</b></sub></a></td>
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
+    <td align="center"><a href='https://linktr.ee/vital.edu'><img src='https://avatars0.githubusercontent.com/u/5282301?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Eduardo Vital Alencar Cunha</b></sub></a></td>
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
-    <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
     <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
     <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
-    <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
     <td align="center"><a href='http://www.linkedin.com/in/tangaudrey'><img src='https://avatars1.githubusercontent.com/u/20723?v=4?s=100' width='100px;' alt=''/><br /><sub><b>唐鳳</b></sub></a></td>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ pol.is an AI powered sentiment gathering platform. More organic than surveys, le
 <!-- Changes to badge text in URLs below, require changes to "name" value in .github/workflows/*.yml -->
 [![Nightly Docker Builds](https://github.com/pol-is/polisServer/workflows/Nightly%20Docker%20Builds/badge.svg)][nightlies]
 [![E2E Tests](https://github.com/pol-is/polisServer/workflows/E2E%20Tests/badge.svg)][e2e-tests]
+[![All Contributors](https://img.shields.io/github/all-contributors/pol-is/polis/all-contributors-redux)](#-contributors)
 
    [nightlies]: https://hub.docker.com/u/polisdemo
    [e2e-tests]: https://github.com/pol-is/polisServer/actions?query=workflow%3A%22E2E+Tests%22
@@ -108,3 +109,23 @@ Please see [`docs/deployment.md`](/docs/deployment.md)
 ## ©️  License
 
 [AGPLv3 with additional permission under section 7](/LICENSE)
+
+## ✨ Contributors
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
+    <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -122,12 +122,13 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='https://sudo-science.com/'><img src='https://avatars0.githubusercontent.com/u/35609?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Benjamin Rosas</b></sub></a></td>
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
+    <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
-    <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -131,12 +131,13 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
+    <td align="center"><a href='http://rileydav.is/'><img src='https://avatars0.githubusercontent.com/u/282503?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Riley Davis</b></sub></a></td>
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
     <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
     <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
-    <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -128,24 +128,25 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='http://joenio.me/'><img src='https://avatars0.githubusercontent.com/u/44172?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Joenio Costa</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/joshsmith2'><img src='https://avatars3.githubusercontent.com/u/3437989?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Josh Smith</b></sub></a></td>
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='https://github.com/patrickas'><img src='https://avatars2.githubusercontent.com/u/264735?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Abi Salloum</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
     <td align="center"><a href='http://rileydav.is/'><img src='https://avatars0.githubusercontent.com/u/282503?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Riley Davis</b></sub></a></td>
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
-    <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
     <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
-    <td align="center"><a href='http://www.linkedin.com/in/tangaudrey'><img src='https://avatars1.githubusercontent.com/u/20723?v=4?s=100' width='100px;' alt=''/><br /><sub><b>唐鳳</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='http://www.linkedin.com/in/tangaudrey'><img src='https://avatars1.githubusercontent.com/u/20723?v=4?s=100' width='100px;' alt=''/><br /><sub><b>唐鳳</b></sub></a></td>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -120,32 +120,33 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tr>
     <td align="center"><a href='https://github.com/ajsmitha7'><img src='https://avatars3.githubusercontent.com/u/8118319?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Andrew Smith</b></sub></a></td>
+    <td align="center"><a href='https://github.com/bamstam'><img src='https://avatars3.githubusercontent.com/u/9203888?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Bamstam</b></sub></a></td>
     <td align="center"><a href='https://sudo-science.com/'><img src='https://avatars0.githubusercontent.com/u/35609?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Benjamin Rosas</b></sub></a></td>
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
     <td align="center"><a href='https://twitter.com/devvmh'><img src='https://avatars3.githubusercontent.com/u/1393708?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Devin Howard</b></sub></a></td>
     <td align="center"><a href='https://github.com/drewhart'><img src='https://avatars0.githubusercontent.com/u/6105510?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Drew Hart</b></sub></a></td>
-    <td align="center"><a href='http://dylanguedes.github.io/'><img src='https://avatars3.githubusercontent.com/u/7079397?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Dylan Guedes</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='http://dylanguedes.github.io/'><img src='https://avatars3.githubusercontent.com/u/7079397?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Dylan Guedes</b></sub></a></td>
     <td align="center"><a href='https://linktr.ee/vital.edu'><img src='https://avatars0.githubusercontent.com/u/5282301?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Eduardo Vital Alencar Cunha</b></sub></a></td>
     <td align="center"><a href='http://joenio.me/'><img src='https://avatars0.githubusercontent.com/u/44172?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Joenio Costa</b></sub></a></td>
     <td align="center"><a href='https://github.com/joshsmith2'><img src='https://avatars3.githubusercontent.com/u/3437989?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Josh Smith</b></sub></a></td>
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='https://github.com/patrickas'><img src='https://avatars2.githubusercontent.com/u/264735?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Abi Salloum</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
-    <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
     <td align="center"><a href='http://rileydav.is/'><img src='https://avatars0.githubusercontent.com/u/282503?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Riley Davis</b></sub></a></td>
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
     <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
     <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
-    <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
     <td align="center"><a href='http://www.linkedin.com/in/tangaudrey'><img src='https://avatars1.githubusercontent.com/u/20723?v=4?s=100' width='100px;' alt=''/><br /><sub><b>唐鳳</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -123,20 +123,21 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='https://sudo-science.com/'><img src='https://avatars0.githubusercontent.com/u/35609?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Benjamin Rosas</b></sub></a></td>
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
+    <td align="center"><a href='http://dylanguedes.github.io/'><img src='https://avatars3.githubusercontent.com/u/7079397?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Dylan Guedes</b></sub></a></td>
     <td align="center"><a href='https://linktr.ee/vital.edu'><img src='https://avatars0.githubusercontent.com/u/5282301?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Eduardo Vital Alencar Cunha</b></sub></a></td>
     <td align="center"><a href='http://joenio.me/'><img src='https://avatars0.githubusercontent.com/u/44172?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Joenio Costa</b></sub></a></td>
-    <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
     <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
     <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
-    <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
+    <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -125,9 +125,10 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
-    <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
+    <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -123,29 +123,30 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='https://sudo-science.com/'><img src='https://avatars0.githubusercontent.com/u/35609?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Benjamin Rosas</b></sub></a></td>
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
+    <td align="center"><a href='https://twitter.com/devvmh'><img src='https://avatars3.githubusercontent.com/u/1393708?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Devin Howard</b></sub></a></td>
     <td align="center"><a href='https://github.com/drewhart'><img src='https://avatars0.githubusercontent.com/u/6105510?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Drew Hart</b></sub></a></td>
     <td align="center"><a href='http://dylanguedes.github.io/'><img src='https://avatars3.githubusercontent.com/u/7079397?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Dylan Guedes</b></sub></a></td>
-    <td align="center"><a href='https://linktr.ee/vital.edu'><img src='https://avatars0.githubusercontent.com/u/5282301?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Eduardo Vital Alencar Cunha</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://linktr.ee/vital.edu'><img src='https://avatars0.githubusercontent.com/u/5282301?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Eduardo Vital Alencar Cunha</b></sub></a></td>
     <td align="center"><a href='http://joenio.me/'><img src='https://avatars0.githubusercontent.com/u/44172?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Joenio Costa</b></sub></a></td>
     <td align="center"><a href='https://github.com/joshsmith2'><img src='https://avatars3.githubusercontent.com/u/3437989?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Josh Smith</b></sub></a></td>
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='https://github.com/patrickas'><img src='https://avatars2.githubusercontent.com/u/264735?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Abi Salloum</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
-    <td align="center"><a href='http://rileydav.is/'><img src='https://avatars0.githubusercontent.com/u/282503?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Riley Davis</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='http://rileydav.is/'><img src='https://avatars0.githubusercontent.com/u/282503?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Riley Davis</b></sub></a></td>
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
     <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
     <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
-    <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
     <td align="center"><a href='http://www.linkedin.com/in/tangaudrey'><img src='https://avatars1.githubusercontent.com/u/20723?v=4?s=100' width='100px;' alt=''/><br /><sub><b>唐鳳</b></sub></a></td>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>

--- a/README.md
+++ b/README.md
@@ -123,29 +123,30 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='https://sudo-science.com/'><img src='https://avatars0.githubusercontent.com/u/35609?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Benjamin Rosas</b></sub></a></td>
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
+    <td align="center"><a href='https://github.com/drewhart'><img src='https://avatars0.githubusercontent.com/u/6105510?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Drew Hart</b></sub></a></td>
     <td align="center"><a href='http://dylanguedes.github.io/'><img src='https://avatars3.githubusercontent.com/u/7079397?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Dylan Guedes</b></sub></a></td>
     <td align="center"><a href='https://linktr.ee/vital.edu'><img src='https://avatars0.githubusercontent.com/u/5282301?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Eduardo Vital Alencar Cunha</b></sub></a></td>
-    <td align="center"><a href='http://joenio.me/'><img src='https://avatars0.githubusercontent.com/u/44172?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Joenio Costa</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='http://joenio.me/'><img src='https://avatars0.githubusercontent.com/u/44172?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Joenio Costa</b></sub></a></td>
     <td align="center"><a href='https://github.com/joshsmith2'><img src='https://avatars3.githubusercontent.com/u/3437989?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Josh Smith</b></sub></a></td>
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='https://github.com/patrickas'><img src='https://avatars2.githubusercontent.com/u/264735?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Abi Salloum</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
     <td align="center"><a href='http://rileydav.is/'><img src='https://avatars0.githubusercontent.com/u/282503?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Riley Davis</b></sub></a></td>
-    <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
     <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
     <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
-    <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
     <td align="center"><a href='http://www.linkedin.com/in/tangaudrey'><img src='https://avatars1.githubusercontent.com/u/20723?v=4?s=100' width='100px;' alt=''/><br /><sub><b>唐鳳</b></sub></a></td>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -119,24 +119,25 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
+    <td align="center"><a href='https://github.com/ajsmitha7'><img src='https://avatars3.githubusercontent.com/u/8118319?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Andrew Smith</b></sub></a></td>
     <td align="center"><a href='https://sudo-science.com/'><img src='https://avatars0.githubusercontent.com/u/35609?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Benjamin Rosas</b></sub></a></td>
     <td align="center"><a href='http://www.metasoarous.com/'><img src='https://avatars3.githubusercontent.com/u/88556?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Christopher Small</b></sub></a></td>
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
     <td align="center"><a href='http://kenwheeler.github.io/'><img src='https://avatars2.githubusercontent.com/u/286616?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ken Wheeler</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/ricardopoppi'><img src='https://avatars3.githubusercontent.com/u/1162183?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Ricardo Poppi</b></sub></a></td>
-    <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
     <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
     <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
-    <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
     <td align="center"><a href='http://www.linkedin.com/in/tangaudrey'><img src='https://avatars1.githubusercontent.com/u/20723?v=4?s=100' width='100px;' alt=''/><br /><sub><b>唐鳳</b></sub></a></td>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
+    <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -128,12 +128,15 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='https://github.com/rohanrichards'><img src='https://avatars2.githubusercontent.com/u/16222002?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Rohan Richards</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='https://github.com/huulbaek'><img src='https://avatars0.githubusercontent.com/u/1862741?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Thomas Huulbæk Titanium</b></sub></a></td>
     <td align="center"><a href='https://github.com/willcohen'><img src='https://avatars0.githubusercontent.com/u/5185341?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Will Cohen</b></sub></a></td>
     <td align="center"><a href='https://github.com/crkrenn'><img src='https://avatars2.githubusercontent.com/u/6069975?v=4?s=100' width='100px;' alt=''/><br /><sub><b>crkrenn</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
     <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
+  </tr>
+  <tr>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='https://pol.is/'><img src='https://avatars3.githubusercontent.com/u/1770265?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Colin Megill</b></sub></a></td>
     <td align="center"><a href='http://nodescription.net/'><img src='https://avatars2.githubusercontent.com/u/305339?v=4?s=100' width='100px;' alt=''/><br /><sub><b>Patrick Connolly</b></sub></a></td>
     <td align="center"><a href='https://github.com/misscs'><img src='https://avatars1.githubusercontent.com/u/51812?v=4?s=100' width='100px;' alt=''/><br /><sub><b>cs</b></sub></a></td>
+    <td align="center"><a href='https://github.com/light24bulbs'><img src='https://avatars2.githubusercontent.com/u/581906?v=4?s=100' width='100px;' alt=''/><br /><sub><b>light24bulbs</b></sub></a></td>
     <td align="center"><a href='https://github.com/mbjorkegren'><img src='https://avatars3.githubusercontent.com/u/2016166?v=4?s=100' width='100px;' alt=''/><br /><sub><b>mbjorkegren</b></sub></a></td>
+  </tr>
+  <tr>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href='http://virgile-dev.github.io/'><img src='https://avatars0.githubusercontent.com/u/11473995?v=4?s=100' width='100px;' alt=''/><br /><sub><b>virgile-dev</b></sub></a></td>
   </tr>
   <tr>
+    <td align="center"><a href='http://www.linkedin.com/in/tangaudrey'><img src='https://avatars1.githubusercontent.com/u/20723?v=4?s=100' width='100px;' alt=''/><br /><sub><b>唐鳳</b></sub></a></td>
     <td align="center"><a href='http://sais.tw/'><img src='https://avatars3.githubusercontent.com/u/2368060?v=4?s=100' width='100px;' alt=''/><br /><sub><b>蔡仲明 (Romulus Urakagi Tsai)</b></sub></a></td>
   </tr>
 </table>


### PR DESCRIPTION
Re-ticketed from #347 

This adds a minimal `.all-contributorsrc` file to the repo root, including only folks who show up on:
https://github.com/pol-is/polis/graphs/contributors

I mostly just used `code` as the key, but for a few people whom clearly didn't seem to be code contributors, I instead opted for using "infra", "test", "doc", "translation".

For now, we're not showing contribution type in the README generation, so the above will only come into play when we decide to start showing that.